### PR TITLE
implement create-command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,71 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create NAME IMAGE",
+	Args:  cobra.ExactArgs(2),
+	Short: "A brief description of your command",
+	Long: `
+Create a new command.
+
+ NAME is the name of the new command, which you will use to execute the command. 
+
+ IMAGE is the OCI image o which the command is based on.
+`,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) < 2 {
+			err := fmt.Errorf("not enough arguments provided, need 2 got %d", len(args))
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+
+	Run: create,
+}
+
+type entity struct {
+	Name      string
+	Parameter string
+	Image     string
+	Command   string
+	Runtime   string
+}
+
+var Entity entity
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+
+	createCmd.Flags().StringVarP(&Entity.Parameter, "parameter", "p", "",
+		"set parameter for running the container")
+
+	createCmd.Flags().StringVarP(&Entity.Image, "command", "c", "",
+		"set the command that should be executed in the container")
+
+	createCmd.Flags().StringVarP(&Entity.Runtime, "runtime", "r", "",
+		"provide container runtime, otherwise the value from the config will be used.")
+}
+
+func create(cmd *cobra.Command, args []string) {
+
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,12 +1,9 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"os"
 )
 
@@ -67,5 +64,9 @@ func init() {
 }
 
 func create(cmd *cobra.Command, args []string) {
+	name, image := args[0], args[1]
+	fmt.Println(name, image)
 
+	value := viper.Get("runtime")
+	fmt.Println(value)
 }

--- a/config/values.go
+++ b/config/values.go
@@ -3,6 +3,7 @@ package config
 func GetConfigStructure() *map[string]string {
 	config := make(map[string]string)
 	config["runtime"] = "docker"
+	config["path"] = "/usr/local/bin/"
 	config["container"] = "{}"
 	return &config
 }


### PR DESCRIPTION
Implement the create-command. The command allows to add a shell alias as a sh-file to the user path. Such a file is named after the wanted command and contains the command to be executed. Example:

file name
> redis-cli

file content
> #!/bin/sh
> podman run -i -t --rm --name redis-cli redis redis-cli "$@"