### PR TITLE
add mode file using build tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 build:
-	go generate
-	go build
+	go build -tags dev
 run:
 	go run cpm.go

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,5 @@ build:
 	go build -tags dev
 run:
 	go run cpm.go
+release:
+	go build

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/n1ckl0sk0rtge/cpm/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os"
+)
+
+// execCmd represents the exec command
+var execCmd = &cobra.Command{
+	Use:   "exec COMMAND",
+	Args:  cobra.ExactArgs(1),
+	Short: "A brief description of your command",
+	Long:  `A longer description that `,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if len(args) != 1 {
+			err := fmt.Errorf("not enough arguments provided, need 1 got %d", len(args))
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	},
+
+	Run: execute,
+}
+
+func init() {
+	rootCmd.AddCommand(execCmd)
+}
+
+func execute(cmd *cobra.Command, args []string) {
+	commandName := args[0]
+
+	viper.Get(config.Container + "." + commandName)
+
+}

--- a/mode.go
+++ b/mode.go
@@ -1,0 +1,16 @@
+//go:build dev
+// +build dev
+
+package main
+
+import (
+	"log"
+	"os"
+)
+
+const DevMode = "CPM_DEV_MODE"
+
+func init() {
+	log.Println("dev mode is enabled!")
+	os.Setenv(DevMode, "true")
+}


### PR DESCRIPTION
This feature add the option for a dev mode to the project. By building the application with the `dev` tag, the development mode will be enabled.

`go build -tags dev` or using the pre-defined makefile command `make build`