### PR TITLE
add path field to config for every command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -111,6 +111,7 @@ func create(_ *cobra.Command, args []string) {
 	viper.Set(config.ContainerImage(name), image)
 	viper.Set(config.ContainerParameter(name), entity.Parameter)
 	viper.Set(config.ContainerCommand(name), entity.Command)
+	viper.Set(config.ContainerPath(name), filePath)
 
 	err = viper.WriteConfig()
 

--- a/config/values.go
+++ b/config/values.go
@@ -18,6 +18,7 @@ const (
 	image     string = "image"
 	parameter string = "parameter"
 	command   string = "command"
+	path      string = "path"
 )
 
 func ContainerImage(name string) string {
@@ -30,4 +31,8 @@ func ContainerParameter(name string) string {
 
 func ContainerCommand(name string) string {
 	return Container + "." + name + "." + command
+}
+
+func ContainerPath(name string) string {
+	return Container + "." + name + "." + path
 }


### PR DESCRIPTION
When creating a new command the path for the new executable will be stored in the config along side the name, image, parameter and command. 